### PR TITLE
Fixing typo in MapLibre Android SDK : "Adnroid" to "Android"

### DIFF
--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -1,7 +1,7 @@
 ext {
     mapLibreArtifactGroupId = 'org.maplibre.gl'
     mapLibreArtifactId = project.hasProperty('POM_ARTIFACT_ID') ? project.property('POM_ARTIFACT_ID') : System.getenv('POM_ARTIFACT_ID')
-    mapLibreArtifactTitle = 'MapLibre Adnroid SDK'
+    mapLibreArtifactTitle = 'MapLibre Android SDK'
     mapLibreArtifactDescription = project.hasProperty('POM_DESCRIPTION') ? project.property('POM_DESCRIPTION') : System.getenv('POM_DESCRIPTION')
     mapLibreDeveloperName = 'MapLibre'
     mapLibreDeveloperEmail = 'maplibre@maplibre.org'


### PR DESCRIPTION
MapLibre Android SDK for Java had an unfortunate typo in the artifact
name. I fixed the typo "Adnroid" to "Android". This should not hurt
anything else except the Maven artifact name will be correctly spelled
now.

test: Local gradle build with artifact name check.
