### PR TITLE
Fixed deprecated method calls and some warnings.

### DIFF
--- a/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
@@ -399,10 +399,16 @@ public final class Feature implements GeoJson {
      * @param key name of the member
      * @return the value of the member, null if it doesn't exist
      * @since 1.0.0
+     * @deprecated 
+     * This method was passing the call to JsonElement::getAsCharacter()
+     * which is in turn deprecated because of misleading nature, as it
+     * does not get this element as a char but rather as a string's first character.
      */
     @Deprecated
+    @Nullable
     public Character getCharacterProperty(String key) {
         JsonElement propertyKey = properties().get(key);
+        //noinspection deprecation
         return propertyKey == null ? null : propertyKey.getAsCharacter();
     }
 

--- a/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Feature.java
@@ -86,7 +86,7 @@ public final class Feature implements GeoJson {
         // Even thought properties are Nullable,
         // Feature object will be created with properties set to an empty object,
         // so that addProperties() would work
-        if (feature.properties() != null) {
+        if (feature.properties != null) {
             return feature;
         }
         return new Feature(TYPE, feature.bbox(),
@@ -178,7 +178,7 @@ public final class Feature implements GeoJson {
      * @return {@link Feature}
      * @since 1.0.0
      */
-    public static Feature fromGeometry(@Nullable Geometry geometry, @NonNull JsonObject properties,
+    public static Feature fromGeometry(@Nullable Geometry geometry, @Nullable JsonObject properties,
                                        @Nullable String id, @Nullable BoundingBox bbox) {
         return new Feature(TYPE, bbox, id, geometry,
                 properties == null ? new JsonObject() : properties);
@@ -258,8 +258,11 @@ public final class Feature implements GeoJson {
      * @return a {@link JsonObject} which holds this features current properties
      * @since 1.0.0
      */
-    @Nullable
+    @NonNull
     public JsonObject properties() {
+        if(properties == null) {
+            throw new IllegalStateException("Properties should not be null");
+        }
         return properties;
     }
 
@@ -397,6 +400,7 @@ public final class Feature implements GeoJson {
      * @return the value of the member, null if it doesn't exist
      * @since 1.0.0
      */
+    @Deprecated
     public Character getCharacterProperty(String key) {
         JsonElement propertyKey = properties().get(key);
         return propertyKey == null ? null : propertyKey.getAsCharacter();
@@ -470,7 +474,7 @@ public final class Feature implements GeoJson {
                     && ((this.geometry == null)
                     ? (that.geometry() == null) : this.geometry.equals(that.geometry()))
                     && ((this.properties == null)
-                    ? (that.properties() == null) : this.properties.equals(that.properties()));
+                    ? (that.properties == null) : this.properties.equals(that.properties()));
         }
         return false;
     }
@@ -555,7 +559,7 @@ public final class Feature implements GeoJson {
                 geometryTypeAdapter.write(jsonWriter, object.geometry());
             }
             jsonWriter.name("properties");
-            if (object.properties() == null) {
+            if (object.properties == null) {
                 jsonWriter.nullValue();
             } else {
                 TypeAdapter<JsonObject> jsonObjectTypeAdapter = this.jsonObjectTypeAdapter;

--- a/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/GeometryCollection.java
@@ -148,8 +148,6 @@ public final class GeometryCollection implements Geometry {
    *
    * @param geometries a non-null list of geometry which makes up this collection
    * @param bbox       optionally include a bbox definition as a double array
-   * @return a new instance of this class defined by the values passed inside this static factory
-   *         method
    * @since 4.6.0
    */
   GeometryCollection(String type, @Nullable BoundingBox bbox, List<Geometry> geometries) {

--- a/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/LineString.java
@@ -155,8 +155,8 @@ public final class LineString implements CoordinateContainer<List<Point>> {
 
   static LineString fromLngLats(double[][] coordinates) {
     ArrayList<Point> converted = new ArrayList<>(coordinates.length);
-    for (int i = 0; i < coordinates.length; i++) {
-      converted.add(Point.fromLngLat(coordinates[i]));
+    for (double[] coordinate : coordinates) {
+      converted.add(Point.fromLngLat(coordinate));
     }
     return LineString.fromLngLats(converted);
   }

--- a/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
@@ -288,11 +288,11 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    * @return a List of {@link LineString}s defining holes inside the polygon
    * @since 3.0.0
    */
-  @Nullable
+  @NonNull
   public List<LineString> inner() {
     List<List<Point>> coordinates = coordinates();
     if (coordinates.size() <= 1) {
-      return new ArrayList(0);
+      return new ArrayList<>(0);
     }
     List<LineString> inner = new ArrayList<>(coordinates.size() - 1);
     for (List<Point> points : coordinates.subList(1, coordinates.size())) {
@@ -375,13 +375,11 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    * ring rules.
    *
    * @param lineString {@link LineString} the polygon geometry
-   * @return true if number of coordinates are 4 or more, and first and last coordinates
-   *   are identical, else false
    * @throws GeoJsonException if number of coordinates are less than 4,
    *   or first and last coordinates are not identical
    * @since 3.0.0
    */
-  private static boolean isLinearRing(LineString lineString) {
+  private static void isLinearRing(LineString lineString) {
     if (lineString.coordinates().size() < 4) {
       throw new GeoJsonException("LinearRings need to be made up of 4 or more coordinates.");
     }
@@ -389,7 +387,6 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
       lineString.coordinates().get(lineString.coordinates().size() - 1)))) {
       throw new GeoJsonException("LinearRings require first and last coordinate to be identical.");
     }
-    return true;
   }
 
   @Override

--- a/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/Polygon.java
@@ -149,7 +149,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    * @since 3.0.0
    */
   public static Polygon fromOuterInner(@NonNull LineString outer, @Nullable LineString... inner) {
-    isLinearRing(outer);
+    ensureIsLinearRing(outer);
     List<List<Point>> coordinates = new ArrayList<>();
     coordinates.add(outer.coordinates());
     // If inner rings are set to null, return early.
@@ -157,7 +157,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
       return new Polygon(TYPE, null, coordinates);
     }
     for (LineString lineString : inner) {
-      isLinearRing(lineString);
+      ensureIsLinearRing(lineString);
       coordinates.add(lineString.coordinates());
     }
     return new Polygon(TYPE, null, coordinates);
@@ -179,7 +179,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    */
   public static Polygon fromOuterInner(@NonNull LineString outer, @Nullable BoundingBox bbox,
                                        @Nullable LineString... inner) {
-    isLinearRing(outer);
+    ensureIsLinearRing(outer);
     List<List<Point>> coordinates = new ArrayList<>();
     coordinates.add(outer.coordinates());
     // If inner rings are set to null, return early.
@@ -187,7 +187,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
       return new Polygon(TYPE, bbox, coordinates);
     }
     for (LineString lineString : inner) {
-      isLinearRing(lineString);
+      ensureIsLinearRing(lineString);
       coordinates.add(lineString.coordinates());
     }
     return new Polygon(TYPE, bbox, coordinates);
@@ -210,7 +210,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    */
   public static Polygon fromOuterInner(@NonNull LineString outer,
                                        @Nullable @Size(min = 1) List<LineString> inner) {
-    isLinearRing(outer);
+    ensureIsLinearRing(outer);
     List<List<Point>> coordinates = new ArrayList<>();
     coordinates.add(outer.coordinates());
     // If inner rings are set to null, return early.
@@ -218,7 +218,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
       return new Polygon(TYPE, null, coordinates);
     }
     for (LineString lineString : inner) {
-      isLinearRing(lineString);
+      ensureIsLinearRing(lineString);
       coordinates.add(lineString.coordinates());
     }
     return new Polygon(TYPE, null, coordinates);
@@ -242,7 +242,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    */
   public static Polygon fromOuterInner(@NonNull LineString outer, @Nullable BoundingBox bbox,
                                        @Nullable @Size(min = 1) List<LineString> inner) {
-    isLinearRing(outer);
+    ensureIsLinearRing(outer);
     List<List<Point>> coordinates = new ArrayList<>();
     coordinates.add(outer.coordinates());
     // If inner rings are set to null, return early.
@@ -250,7 +250,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
       return new Polygon(TYPE, bbox, coordinates);
     }
     for (LineString lineString : inner) {
-      isLinearRing(lineString);
+      ensureIsLinearRing(lineString);
       coordinates.add(lineString.coordinates());
     }
     return new Polygon(TYPE, bbox, coordinates);
@@ -275,7 +275,7 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    * @return a {@link LineString} defining the outer perimeter of this polygon
    * @since 3.0.0
    */
-  @Nullable
+  @NonNull
   public LineString outer() {
     return LineString.fromLngLats(coordinates().get(0));
   }
@@ -376,10 +376,10 @@ public final class Polygon implements CoordinateContainer<List<List<Point>>> {
    *
    * @param lineString {@link LineString} the polygon geometry
    * @throws GeoJsonException if number of coordinates are less than 4,
-   *   or first and last coordinates are not identical
+   *   or first and last coordinates are not identical (it is not linear ring)
    * @since 3.0.0
    */
-  private static void isLinearRing(LineString lineString) {
+  private static void ensureIsLinearRing(LineString lineString) {
     if (lineString.coordinates().size() < 4) {
       throw new GeoJsonException("LinearRings need to be made up of 4 or more coordinates.");
     }

--- a/services-geojson/src/main/java/com/mapbox/geojson/internal/typeadapters/RuntimeTypeAdapterFactory.java
+++ b/services-geojson/src/main/java/com/mapbox/geojson/internal/typeadapters/RuntimeTypeAdapterFactory.java
@@ -131,8 +131,8 @@ import com.google.gson.stream.JsonWriter;
 public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   private final Class<?> baseType;
   private final String typeFieldName;
-  private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<String, Class<?>>();
-  private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<Class<?>, String>();
+  private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<>();
+  private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<>();
   private final boolean maintainType;
 
   private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName, boolean maintainType) {
@@ -158,7 +158,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType,
                                                     String typeFieldName,
                                                     boolean maintainType) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName, maintainType);
+    return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName, maintainType);
   }
 
   /**
@@ -171,7 +171,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
    * @return The RuntimeTypeAdaptorFactory instance created
    */
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName, false);
+    return new RuntimeTypeAdapterFactory<>(baseType, typeFieldName, false);
   }
 
   /**
@@ -183,7 +183,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
    * @return The RuntimeTypeAdaptorFactory instance created
    */
   public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
-    return new RuntimeTypeAdapterFactory<T>(baseType, "type", false);
+    return new RuntimeTypeAdapterFactory<>(baseType, "type", false);
   }
 
   /**
@@ -217,6 +217,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
    *     have already been registered on this type adapter.
    * @return The same object it is called on, so the calls can be chained
    */
+  @SuppressWarnings("unused")
   public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
     return registerSubtype(type, type.getSimpleName());
   }
@@ -228,9 +229,9 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
     }
 
     final Map<String, TypeAdapter<?>> labelToDelegate
-            = new LinkedHashMap<String, TypeAdapter<?>>();
+            = new LinkedHashMap<>();
     final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
-            = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
+            = new LinkedHashMap<>();
     for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
       TypeAdapter<?> delegate =
         gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
@@ -238,6 +239,7 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
       subtypeToDelegate.put(entry.getValue(), delegate);
     }
 
+    //noinspection RedundantThrows
     return new TypeAdapter<R>() {
       @Override public R read(JsonReader in) throws IOException {
         JsonElement jsonElement = Streams.parse(in);

--- a/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/FeatureTest.java
@@ -233,9 +233,6 @@ public class FeatureTest extends TestUtils {
 
     value = feature.getNumberProperty("does_not_exist");
     assertNull(value);
-
-    value = feature.getCharacterProperty("does_not_exist");
-    assertNull(value);
   }
 
   @Test
@@ -253,9 +250,6 @@ public class FeatureTest extends TestUtils {
 
     value = feature.getNumberProperty("does_not_exist");
     assertNull(value);
-
-    value = feature.getCharacterProperty("does_not_exist");
-    assertNull(value);
-
+    
   }
 }

--- a/services-geojson/src/test/java/com/mapbox/geojson/TestUtils.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/TestUtils.java
@@ -23,8 +23,7 @@ public class TestUtils {
   public static final String ACCESS_TOKEN = "pk.XXX";
 
   public void compareJson(String expectedJson, String actualJson) {
-    JsonParser parser = new JsonParser();
-    assertThat(parser.parse(actualJson), Matchers.equalTo(parser.parse(expectedJson)));
+    assertThat(JsonParser.parseString(actualJson), Matchers.equalTo(JsonParser.parseString(expectedJson)));
   }
 
   protected String loadJsonFixture(String filename) throws IOException {

--- a/services-geojson/src/test/java/com/mapbox/geojson/shifter/ShifterTest.java
+++ b/services-geojson/src/test/java/com/mapbox/geojson/shifter/ShifterTest.java
@@ -170,8 +170,7 @@ public class ShifterTest {
   }
 
   public void compareJson(String expectedJson, String actualJson) {
-    JsonParser parser = new JsonParser();
-    assertThat(parser.parse(actualJson), Matchers.equalTo(parser.parse(expectedJson)));
+    assertThat(JsonParser.parseString(actualJson), Matchers.equalTo(JsonParser.parseString(expectedJson)));
   }
 
 }

--- a/services-turf/src/main/java/com/mapbox/turf/TurfAssertions.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfAssertions.java
@@ -69,7 +69,7 @@ public final class TurfAssertions {
       throw new TurfException(String.format(
         "Invalid input to %s, Feature with geometry required", name));
     }
-    if (feature.geometry() == null || !feature.geometry().type().equals(type)) {
+    if (!feature.geometry().type().equals(type)) {
       throw new TurfException(String.format(
         "Invalid input to %s: must be a %s, given %s", name, type, feature.geometry().type()));
     }
@@ -99,7 +99,7 @@ public final class TurfAssertions {
         throw new TurfException(String.format(
           "Invalid input to %s, Feature with geometry required", name));
       }
-      if (feature.geometry() == null || !feature.geometry().type().equals(type)) {
+      if (!feature.geometry().type().equals(type)) {
         throw new TurfException(String.format(
           "Invalid input to %s: must be a %s, given %s", name, type, feature.geometry().type()));
       }

--- a/services-turf/src/main/java/com/mapbox/turf/TurfConversion.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfConversion.java
@@ -353,11 +353,11 @@ public final class TurfConversion {
    * If the original FeatureCollection parameter has {@link Point}(s)
    * and/or {@link MultiPoint}s), the returned
    * FeatureCollection will include a {@link MultiPoint} object.
-   *
+   * <p></p>
    * If the original FeatureCollection parameter has
    * {@link LineString}(s) and/or {@link MultiLineString}s), the returned
    * FeatureCollection will include a {@link MultiLineString} object.
-   *
+   * <p></p>
    * If the original FeatureCollection parameter has
    * {@link Polygon}(s) and/or {@link MultiPolygon}s), the returned
    * FeatureCollection will include a {@link MultiPolygon} object.

--- a/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMeasurement.java
@@ -672,11 +672,11 @@ public final class TurfMeasurement {
    * Calculate the approximate area of the polygon were it projected onto the earth.
    * Note that this area will be positive if ring is oriented clockwise, otherwise
    * it will be negative.
-   *
+   * <p></p>
    * Reference:
    * Robert. G. Chamberlain and William H. Duquette, "Some Algorithms for Polygons on a Sphere",
    * JPL Publication 07-03, Jet Propulsion
-   * Laboratory, Pasadena, CA, June 2007 https://trs.jpl.nasa.gov/handle/2014/41271
+   * Laboratory, Pasadena, CA, June 2007 <a href="https://trs.jpl.nasa.gov/handle/2014/41271">JPL Publication 07-03</a>
    *
    * @param coordinates  A list of {@link Point} of Ring Coordinates
    * @return The approximate signed geodesic area of the polygon in square meters.

--- a/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
+++ b/services-turf/src/main/java/com/mapbox/turf/TurfMisc.java
@@ -131,7 +131,7 @@ public final class TurfMisc {
    * Takes a {@link LineString}, a specified distance along the line to a start {@link Point},
    * and a specified distance along the line to a stop point,
    * returns a subsection of the line in-between those points.
-   *
+   * <p></p>
    * This can be useful for extracting only the part of a route between two distances.
    *
    * @param line input line

--- a/services-turf/src/test/java/com/mapbox/turf/TestUtils.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TestUtils.java
@@ -28,8 +28,7 @@ public class TestUtils {
   public static final String ACCESS_TOKEN = "pk.XXX";
 
   public void compareJson(String expectedJson, String actualJson) {
-    JsonParser parser = new JsonParser();
-    assertThat(parser.parse(actualJson), Matchers.equalTo(parser.parse(expectedJson)));
+    assertThat(JsonParser.parseString(actualJson), Matchers.equalTo(JsonParser.parseString(expectedJson)));
   }
 
   protected String loadJsonFixture(String filename) {

--- a/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
+++ b/services-turf/src/test/java/com/mapbox/turf/TurfMeasurementTest.java
@@ -475,37 +475,37 @@ public class TurfMeasurementTest extends TestUtils {
 
   @Test
   public void square(){
-    BoundingBox bbox1 =  BoundingBox.fromCoordinates(0, 0, 5, 10);
-    BoundingBox bbox2 = BoundingBox.fromCoordinates(0, 0, 10, 5);
+    BoundingBox bbox1 =  BoundingBox.fromLngLats(0, 0, 5, 10);
+    BoundingBox bbox2 = BoundingBox.fromLngLats(0, 0, 10, 5);
 
     BoundingBox sq1 = TurfMeasurement.square(bbox1);
     BoundingBox sq2 = TurfMeasurement.square(bbox2);
 
-    assertEquals(BoundingBox.fromCoordinates(-2.5, 0, 7.5, 10), sq1);
-    assertEquals(BoundingBox.fromCoordinates(0, -2.5, 10, 7.5), sq2);
+    assertEquals(BoundingBox.fromLngLats(-2.5, 0, 7.5, 10), sq1);
+    assertEquals(BoundingBox.fromLngLats(0, -2.5, 10, 7.5), sq2);
   }
 
   @Test
   public void areaPolygon() {
-    double expected = Double.valueOf(loadJsonFixture(TURF_AREA_POLYGON_RESULT));
+    double expected = Double.parseDouble(loadJsonFixture(TURF_AREA_POLYGON_RESULT));
     assertEquals(expected, TurfMeasurement.area(Feature.fromJson(loadJsonFixture(TURF_AREA_POLYGON_GEOJSON))), 1);
   }
 
   @Test
   public void areaMultiPolygon() {
-    double expected = Double.valueOf(loadJsonFixture(TURF_AREA_MULTIPOLYGON_RESULT));
+    double expected = Double.parseDouble(loadJsonFixture(TURF_AREA_MULTIPOLYGON_RESULT));
     assertEquals(expected, TurfMeasurement.area(Feature.fromJson(loadJsonFixture(TURF_AREA_MULTIPOLYGON_GEOJSON))), 1);
   }
 
   @Test
   public void areaGeometry() {
-    double expected = Double.valueOf(loadJsonFixture(TURF_AREA_GEOM_POLYGON_RESULT));
+    double expected = Double.parseDouble(loadJsonFixture(TURF_AREA_GEOM_POLYGON_RESULT));
     assertEquals(expected, TurfMeasurement.area(Polygon.fromJson(loadJsonFixture(TURF_AREA_GEOM_POLYGON_GEOJSON))), 1);
   }
 
   @Test
   public void areaFeatureCollection() {
-    double expected = Double.valueOf(loadJsonFixture(TURF_AREA_FEATURECOLLECTION_POLYGON_RESULT));
+    double expected = Double.parseDouble(loadJsonFixture(TURF_AREA_FEATURECOLLECTION_POLYGON_RESULT));
     assertEquals(expected, TurfMeasurement.area(FeatureCollection.fromJson(loadJsonFixture(TURF_AREA_FEATURECOLLECTION_POLYGON_GEOJSON))), 1);
   }
 


### PR DESCRIPTION
Fixed a few deprecated methods
Cleaned up nullability related warnings with the Feature class
Added missing JavaDoc return annotations
Added new lines to JavaDoc where needed
Removed unnecessary return type in Polygon.java's isLinerRing method, which should probably be renamed to ensureIsLinearRing as it throws an exception if it is not.
Removed unnecessary template type specifications thus fixing more warnings
Deprecated getCharacterProperty as it is deprecated in underlying implementation
Avoided unnecessary boxing (and fixed warning) by replacing Double.ValueOf() with  Double.parseDouble()
Removed unnecessary null checks