### PR TITLE
Revert `Feature.properties()` @NonNull

### DIFF
--- a/services-geojson/src/main/java/org/maplibre/geojson/Feature.java
+++ b/services-geojson/src/main/java/org/maplibre/geojson/Feature.java
@@ -258,11 +258,8 @@ public final class Feature implements GeoJson {
    * @return a {@link JsonObject} which holds this features current properties
    * @since 1.0.0
    */
-  @NonNull
+  @Nullable
   public JsonObject properties() {
-    if (properties == null) {
-      throw new IllegalStateException("Properties should not be null");
-    }
     return properties;
   }
 


### PR DESCRIPTION
https://github.com/maplibre/maplibre-java/commit/92cf8868024fde2a285ab1a6739d49dfd6f1b0af#diff-b129f8fba34141a50a502528733f18b73369810cfef03c8f16a00aa38fcc6355 as part of https://github.com/maplibre/maplibre-java/pull/12 made `Feature.properties()` `@NonNull`, but this breaks existing code. Properties being `@Nullable` on construction a `@NonNull` throwing getter is also not a good API in my opinion.